### PR TITLE
ログ出力修正

### DIFF
--- a/pkg/inbound/payment_controller.go
+++ b/pkg/inbound/payment_controller.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"sync"
 
@@ -47,7 +46,7 @@ func (p *PaymentController) Create(w http.ResponseWriter, r *http.Request) {
 	case "POST":
 		doCreate(w, r, p.svc)
 	default:
-		log.Fatalf("%s Method not allowed.\n", r.Method)
+		zap.S().Fatalf("%s Method not allowed.\n", r.Method)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
 }
@@ -57,7 +56,7 @@ func (p *PaymentController) RejectCreate(w http.ResponseWriter, r *http.Request)
 	case "POST":
 		doRejectCreate(w, r, p.svc)
 	default:
-		log.Fatalf("%s Method not allowed.\n", r.Method)
+		zap.S().Fatalf("%s Method not allowed.\n", r.Method)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
 }

--- a/pkg/outbound/cosmosdb/payment_repository.go
+++ b/pkg/outbound/cosmosdb/payment_repository.go
@@ -83,7 +83,7 @@ func (p *paymentRepository) PutPayment(ctx context.Context, model *domain.Paymen
 		return nil, err
 	}
 	if result.InsertedID != nil {
-		zap.S().Infow("added Payment : " + result.InsertedID.(string))
+		zap.S().Infof("added Payment : %v", result.InsertedID)
 	}
 	return model, nil
 }
@@ -110,7 +110,7 @@ func (p *paymentRepository) PutPaymentHistory(ctx context.Context, model *domain
 		return err
 	}
 	if result.InsertedID != nil {
-		zap.S().Infow("added PaymentHistory : " + result.InsertedID.(string))
+		zap.S().Infof("added PaymentHistory : %v", result.InsertedID)
 	}
 	return nil
 }
@@ -146,7 +146,7 @@ func (p *paymentRepository) DeletePayment(ctx context.Context, orderNo string) e
 	collection := p.db.Database("Payment").Collection("Payment")
 	result, err := collection.UpdateOne(ctx, filter, update)
 	if result.UpsertedID != nil {
-		zap.S().Infow("added Payment : " + result.UpsertedID.(string))
+		zap.S().Infof("deleted Payment : %v", result.UpsertedID)
 	}
 	return err
 }


### PR DESCRIPTION
InsertedID(UpdatedID)が文字列出力できなかったため、オブジェクトの情報をデフォルトフォーマットで出力するように修正。
エラー発生個所が下記のように正常にログ出力されることを確認。

Payment

2022-09-27T08:15:48.129Z        INFO    cosmosdb/payment_repository.go:113      added PaymentHistory : ObjectID("6332b134e67aa02889b25c68")
2022-09-27T08:15:48.147Z        INFO    cosmosdb/payment_repository.go:86       added Payment : ObjectID("6332b134e67aa02889b25c69")

Credit

2022-09-27T08:15:48.144Z        INFO    cosmosdb/credit_repository.go:64        added CreditPayment ID : ObjectID("6332b1347654c2aa16385b02")
